### PR TITLE
Fixed Bug: default image being deleted in profile edit when user has …

### DIFF
--- a/profile-edit/includes/profile-edit.inc.php
+++ b/profile-edit/includes/profile-edit.inc.php
@@ -116,12 +116,14 @@ if (isset($_POST['update-profile'])) {
                         *   Deleting old profile photo
                         * -------------------------------------------------------------------------------
                         */
-                        if (!unlink('../../assets/uploads/users/' . $_SESSION['profile_image'])) {  
+						if ( $_SESSION['profile_image'] != "_defaultUser.png" ) {
+							if (!unlink('../../assets/uploads/users/' . $_SESSION['profile_image'])) {  
 
-                            $_SESSION['ERRORS']['imageerror'] = 'old image could not be deleted';
-                            header("Location: ../");
-                            exit();
-                        } 
+								$_SESSION['ERRORS']['imageerror'] = 'old image could not be deleted';
+								header("Location: ../");
+								exit();
+							} 
+						}
                     }
                     else
                     {


### PR DESCRIPTION
This should fix a minor bug where, provided the user has not uploaded a profile picture during registration, the default profile image would be deleted when the user replaced their profile image in profile edit. 