### PR TITLE
Fix for contact email form

### DIFF
--- a/contact/includes/contact.inc.php
+++ b/contact/includes/contact.inc.php
@@ -76,7 +76,7 @@ if (isset($_POST['contact-submit'])) {
 	}
 
 	//check if the message is longer than 20 characters.
-	elseif(strlen($msg) >= 20){
+	elseif(strlen($msg) <= 20){
 	
 		$_SESSION['ERRORS']['mailstatus'] = 'Message should be longer than 20 characters';
 		header("Location: ../");
@@ -84,7 +84,7 @@ if (isset($_POST['contact-submit'])) {
 	}
 
 	//check if the message is shorter than 500 characters.
-	elseif(strlen($msg) <= 500){
+	elseif(strlen($msg) >= 500){
 	
 		$_SESSION['ERRORS']['mailstatus'] = 'Message should be shorter than 500 characters';
 		header("Location: ../");

--- a/contact/index.php
+++ b/contact/index.php
@@ -30,6 +30,13 @@ include '../assets/layouts/header.php';
 
                         ?>
                     </small>
+                    <small class="text-danger font-weight-bold">
+                        <?php
+                            if (isset($_SESSION['ERRORS']['mailstatus']))
+                                echo $_SESSION['ERRORS']['mailstatus'];
+
+                        ?>
+                    </small>
                 </div>
 
                 <?php if(!isset($_SESSION['auth'])) { ?>


### PR DESCRIPTION
Finally, found the issue with the contact form. It was aborting because the > and < were reversed, so it aborted in all situations.

Also, I threw in Error reporting in the contact index page because it wasn't showing the error messages like "Message must be longer than 20 characters" and so on.

Works fine now.